### PR TITLE
Add fast embeddings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.3.0]
+
+- Added a base Bert Tiny model to support lightning-fast embeddings (alias `tiny_embed`). See `?embed` for more details.
+
+
 ## [0.2.0]
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FlashRank"
 uuid = "22cc3f58-1757-4700-bb45-2032706e5a8d"
 authors = ["J S <49557684+svilupp@users.noreply.github.com> and contributors"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 DataDeps = "124859b0-ceae-595e-8997-d05f6a7a8dfe"

--- a/src/FlashRank.jl
+++ b/src/FlashRank.jl
@@ -20,7 +20,11 @@ export RankerModel, RankResult
 ## export rank # not exported to avoid name clash with PromptingTools
 include("ranking.jl")
 
+export EmbedderModel, EmbedResult
+include("embedding.jl")
+
 function __init__()
+    ## Ranking models
     ## Acknowledgement: The weights come from Prithiviraj Damodaran's HF space: https://huggingface.co/prithivida/flashrank/tree/main
     register(DataDep("ms-marco-TinyBERT-L-2-v2",
         """
@@ -48,6 +52,15 @@ function __init__()
         MiniLM-L-6-v2 cross-encoder trained on the ms-marco dataset, FP32 precision.
         """,
         "https://huggingface.co/svilupp/onnx-cross-encoders/resolve/main/ms-marco-MiniLM-L-6-v2-onnx.zip";
+        post_fetch_method = unpack
+    ))
+    ## Embedding models - for acknowledgement, see the model cards in the archives and on HuggingFace
+    register(DataDep("base-TinyBERT-L-4-v2",
+        """
+        TinyBERT-L-4-v2 model used for mean pooled embeddings.
+        """,
+        "https://huggingface.co/svilupp/onnx-embedders/resolve/main/TinyBERT_L-4_H-312_v2-onnx.zip",
+        "04cc21a09f4675d07a1a12c02b9482f58d2087a8bda6825bf86289efced6582b";
         post_fetch_method = unpack
     ))
 end

--- a/src/embedding.jl
+++ b/src/embedding.jl
@@ -1,0 +1,85 @@
+
+abstract type AbstractEmbedderModel end
+
+"""
+    EmbedderModel
+
+A model for embedding passages, including the encoder and the ONNX session for inference.
+
+For embedding, use as `embed(embedder, passages)` or as a functor `embedder(passages)`.
+
+"""
+struct EmbedderModel <: AbstractEmbedderModel
+    alias::Symbol
+    encoder::BertTextEncoder
+    session::ORT.InferenceSession
+end
+function Base.show(io::IO, result::AbstractEmbedderModel)
+    dump(io, result; maxdepth = 1)
+end
+
+function EmbedderModel(alias::Symbol = :tiny)
+    encoder, session = load_model(alias)
+    EmbedderModel(alias, encoder, session)
+end
+
+"""
+    EmbedResult{T <: Real}
+
+The result of embedding passages.
+
+# Fields
+- `embeddings::AbstractArray{T}`: The embeddings of the passages. With property `embeddings` as column-major matrix of size `(batch_size, embedding_dimension)`.
+- `elapsed::Float64`: The time taken to embed the passages.
+"""
+struct EmbedResult{T <: Real}
+    embeddings::AbstractArray{T}
+    elapsed::Float64
+end
+function Base.show(io::IO, result::EmbedResult)
+    dump(io, result; maxdepth = 1)
+end
+
+"""
+    embed(
+        embedder::EmbedderModel, passages::AbstractVector{<:AbstractString})
+
+Embeds `passages` using the given `embedder` model.
+
+# Arguments:
+- `embedder::EmbedderModel`: The embedder model to use.
+- `passages::AbstractVector{<:AbstractString}`: The passages to embed.
+
+# Returns
+- `EmbedResult`: The embeddings of the passages. With property `embeddings` as column-major matrix of size `(batch_size, embedding_dimension)`.
+
+# Example
+```julia
+model = EmbedderModel(:tiny_embed)
+result = embed(model, ["Hello, how are you?", "How is it going?"])
+result.embeddings # 312x2 matrix of Float32
+```
+"""
+function embed(
+        embedder::EmbedderModel, passages::AbstractVector{<:AbstractString})
+    t = @elapsed begin
+        token_ids, token_type_ids, attention_mask = encode(embedder.encoder, passages)
+        ## transpose as the model expects row-major
+        ## TODO: investigate pre-warming the session with padded inputs
+        ## TODO: investigate performnance on materialized inputs
+        onnx_input = Dict("input_ids" => token_ids', "attention_mask" => attention_mask')
+        out = embedder.session(onnx_input)
+        ## Permute dimensions to return column-major embeddings, ie, batch-size X embedding-size
+        embeddings = out["avg_embeddings"] |> permutedims
+    end
+    EmbedResult(embeddings, t)
+end
+
+function embed(embedder::EmbedderModel, passages::AbstractString)
+    embed(embedder, [passages])
+end
+
+function (embedder::EmbedderModel)(
+        passages::Union{AbstractString, AbstractVector{<:AbstractString}}; kwargs...)
+    embed(embedder, passages; kwargs...)
+end

--- a/src/encoder.jl
+++ b/src/encoder.jl
@@ -135,3 +135,36 @@ function encode(enc::BertTextEncoder, query::AbstractString,
     end
     return token_ids, token_type_ids, attention_mask
 end
+
+# For multiple documents
+function FlashRank.encode(enc::BertTextEncoder, passages::AbstractVector{<:AbstractString};
+        add_special_tokens::Bool = true)
+    tokens_vec = [tokenize(enc, passage; add_special_tokens = true, token_ids = true)
+                  for passage in passages]
+    max_len = maximum(length, tokens_vec) |>
+              x -> isnothing(enc.trunc) ? x : min(x, enc.trunc)
+
+    ## Assumes that padding is done with token ID 0
+    token_ids = zeros(Int, max_len, length(passages))
+    # Zero indexed as models are trained for Python
+    token_type_ids = zeros(Int, max_len, length(passages))
+    attention_mask = zeros(Int, max_len, length(passages))
+
+    ## Encode to token IDS
+    @inbounds for j in eachindex(tokens_vec)
+        tokens = tokens_vec[j]
+        for i in eachindex(tokens)
+            if i > max_len
+                break
+            elseif i == max_len
+                ## give [SEP] token
+                token_ids[i, j] = enc.vocab[enc.endsym]
+            else
+                ## fill the tokens
+                token_ids[i, j] = tokens[i]
+            end
+            attention_mask[i, j] = 1
+        end
+    end
+    return token_ids, token_type_ids, attention_mask
+end

--- a/src/loader.jl
+++ b/src/loader.jl
@@ -21,12 +21,15 @@ function load_model(alias::Symbol)
         datadep"ms-marco-MiniLM-L-6-v2"
     elseif alias == :mini4
         datadep"ms-marco-MiniLM-L-4-v2"
+    elseif alias == :tiny_embed
+        datadep"base-TinyBERT-L-4-v2"
     else
         throw(ArgumentError("Invalid model type"))
     end
 
     # Tokenizer setup
     tok_path = find_file(model_root, "tokenizer.json")
+    special_tokens_map_path = find_file(model_root, "special_tokens_map.json")
     tok_config_path = find_file(model_root, "tokenizer_config.json")
     vocab_path = find_file(model_root, "vocab.txt")
     if !isnothing(tok_path)
@@ -49,7 +52,9 @@ function load_model(alias::Symbol)
         enc = BertTextEncoder(wp, vocab; trunc)
     elseif !isnothing(tok_config_path) && !isnothing(vocab_path)
         ## Load from tokenizer_config.json
+        special_tokens_map = JSON3.read(special_tokens_map_path)
         tok_config = JSON3.read(tok_config_path)
+        tok_config = merge(tok_config, special_tokens_map)
         vocab_list = readlines(vocab_path)
 
         ## Double check that all tokens are in vocab

--- a/test/embedding.jl
+++ b/test/embedding.jl
@@ -1,0 +1,43 @@
+using FlashRank: EmbedderModel, embed
+
+@testset "embed" begin
+    embedder = EmbedderModel(:tiny_embed)
+
+    texts = ["Hello, how are you?", "How is it going?",
+        "I am fine, thank you.", "I had a coffee for breakfast"]
+
+    # Calculate cosine similarity between the embeddings of the three texts
+    function cosine_similarity(x, y)
+        dot_product = sum(x .* y)
+        norm_x = sqrt(sum(x .^ 2))
+        norm_y = sqrt(sum(y .^ 2))
+        return dot_product / (norm_x * norm_y)
+    end
+
+    result = embed(embedder, texts)
+    @test result.embeddings isa AbstractArray{Float32}
+    @test size(result.embeddings) == (312, 4)
+    embeddings = result.embeddings
+    cos_sim_12 = cosine_similarity(embeddings[:, 1], embeddings[:, 2])
+    cos_sim_13 = cosine_similarity(embeddings[:, 1], embeddings[:, 3])
+    cos_sim_14 = cosine_similarity(embeddings[:, 1], embeddings[:, 4])
+    cos_sim_23 = cosine_similarity(embeddings[:, 2], embeddings[:, 3])
+    cos_sim_24 = cosine_similarity(embeddings[:, 2], embeddings[:, 4])
+    cos_sim_34 = cosine_similarity(embeddings[:, 3], embeddings[:, 4])
+
+    @test isapprox(cos_sim_12, 0.75847805; atol = 5e-2)
+    @test isapprox(cos_sim_13, 0.4089551; atol = 5e-2)
+    @test isapprox(cos_sim_14, 0.28373927; atol = 5e-2)
+    @test isapprox(cos_sim_23, 0.32157198; atol = 5e-2)
+    @test isapprox(cos_sim_24, 0.35012797; atol = 5e-2)
+    @test isapprox(cos_sim_34, 0.27234405; atol = 5e-2)
+
+    ## Different functor interface
+    result = embedder(texts)
+    @test result.embeddings isa AbstractArray{Float32}
+    @test size(result.embeddings) == (312, 4)
+
+    result = embedder(texts[1])
+    @test result.embeddings isa AbstractArray{Float32}
+    @test size(result.embeddings) == (312, 1)
+end

--- a/test/embedding.jl
+++ b/test/embedding.jl
@@ -1,4 +1,4 @@
-using FlashRank: EmbedderModel, embed
+using FlashRank: EmbedderModel, embed, EmbedResult
 
 @testset "embed" begin
     embedder = EmbedderModel(:tiny_embed)
@@ -40,4 +40,24 @@ using FlashRank: EmbedderModel, embed
     result = embedder(texts[1])
     @test result.embeddings isa AbstractArray{Float32}
     @test size(result.embeddings) == (312, 1)
+end
+
+@testset "show-embedding" begin
+    embedder = EmbedderModel(:tiny_embed)
+    io = IOBuffer()
+    show(io, embedder)
+    output = String(take!(io))
+    @test occursin("tiny_embed", output)
+    @test occursin("BertTextEncoder", output)
+    @test occursin("InferenceSession", output)
+
+    result = EmbedResult(rand(Float32, 312, 4), 0.1)
+    io = IOBuffer()
+    show(io, result)
+    output = String(take!(io))
+    @test occursin("EmbedResult{Float32}", output)
+    @test occursin("(312, 4)", output)
+    @test occursin("0.1", output)
+    @test occursin("embeddings", output)
+    @test occursin("elapsed", output)
 end

--- a/test/encoder.jl
+++ b/test/encoder.jl
@@ -212,4 +212,13 @@ using FlashRank: RankerModel, tokenize, encode
     ## Attention mask
     @test out[3][512, :] == [0, 1, 0]
     @test sum(out[3]) == 512 + 33 + 39
+
+    ### Encoding multiple sequences
+    texts = ["Hello, how are you?", "I am fine, thank you."]
+    output = encode(encoder, texts)
+    @test output[1] ==
+          [101 101; 7592 1045; 1010 2572; 2129 2986; 2024 1010; 2017 4067; 1029 2017;
+           102 1012; 0 102]
+    @test all(iszero, output[2])
+    @test output[3] == [1 1; 1 1; 1 1; 1 1; 1 1; 1 1; 1 1; 1 1; 0 1]
 end

--- a/test/ranking.jl
+++ b/test/ranking.jl
@@ -1,4 +1,4 @@
-using FlashRank: RankerModel, rank
+using FlashRank: RankerModel, rank, RankResult
 
 @testset "rank" begin
     ranker = RankerModel(:tiny)
@@ -33,4 +33,25 @@ using FlashRank: RankerModel, rank
     @test result.docs[1] == passages[5]
     @test length(result.docs) == 5
     @test isapprox(result.scores[1], 0.0004; atol = 5e-4)
+end
+
+@testset "show-ranker" begin
+    ranker = RankerModel(:tiny)
+    io = IOBuffer()
+    show(io, ranker)
+    output = String(take!(io))
+    @test occursin("RankerModel", output)
+    @test occursin("tiny", output)
+    @test occursin("BertTextEncoder", output)
+    @test occursin("InferenceSession", output)
+
+    result = RankResult("a", ["b", "c"], [1, 2], [0.1f0, 0.2f0], 0.3)
+    io = IOBuffer()
+    show(io, result)
+    output = String(take!(io))
+    @test occursin("RankResult", output)
+    @test occursin("a", output)
+    @test occursin("positions", output)
+    @test occursin("scores", output)
+    @test occursin("elapsed", output)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,4 +10,5 @@ using Aqua
     include("loader.jl")
     include("encoder.jl")
     include("ranking.jl")
+    include("embedding.jl")
 end


### PR DESCRIPTION
- A base Bert Tiny model was added to support lightning-fast embeddings (alias `tiny_embed`). See `?embed` for more details.
