### PR TITLE
Split-Embedding of long texts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.4.0]
+
+### Added
+- Simplify embedding with the tiny models and provide native support for splitting of long strings into several smaller ones (kwarg `split_instead_trunc`)
+
 ## [0.3.0]
 
+### Added
 - Added a base Bert Tiny model to support lightning-fast embeddings (alias `tiny_embed`). See `?embed` for more details.
 
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FlashRank"
 uuid = "22cc3f58-1757-4700-bb45-2032706e5a8d"
 authors = ["J S <49557684+svilupp@users.noreply.github.com> and contributors"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 DataDeps = "124859b0-ceae-595e-8997-d05f6a7a8dfe"

--- a/test/embedding.jl
+++ b/test/embedding.jl
@@ -40,6 +40,15 @@ using FlashRank: EmbedderModel, embed, EmbedResult
     result = embedder(texts[1])
     @test result.embeddings isa AbstractArray{Float32}
     @test size(result.embeddings) == (312, 1)
+
+    ## Splitting - no effect
+    result = embed(embedder, texts[1]; split_instead_trunc = true)
+    @test size(result.embeddings) == (312, 1)
+
+    # split when long text
+    long_text = repeat("Hello, how are you? ", 200)
+    result = embed(embedder, long_text; split_instead_trunc = true)
+    @test size(result.embeddings) == (312, 3)
 end
 
 @testset "show-embedding" begin

--- a/test/encoder.jl
+++ b/test/encoder.jl
@@ -221,4 +221,36 @@ using FlashRank: RankerModel, tokenize, encode
            102 1012; 0 102]
     @test all(iszero, output[2])
     @test output[3] == [1 1; 1 1; 1 1; 1 1; 1 1; 1 1; 1 1; 1 1; 0 1]
+
+    ## # Encode with splitting
+    long_text = repeat("Hello, how are you? ", 100)
+
+    output = encode(encoder, long_text; split_instead_trunc = true)
+    @test size(output[1]) == (512, 2)
+    ## check that tokens were added correctly
+    @test output[1][1, :] == [101, 101]
+    @test output[1][end, :] == [102, 0]
+    @test output[1][93, 2] == 102
+    @test output[1][94, 2] == 0
+    @test size(output[3]) == (512, 2)
+    @test output[3][1, :] == [1, 1]
+    @test output[3][end, :] == [1, 0]
+    @test output[3][93, :] == [1, 1]
+    @test output[3][94, :] == [1, 0]
+    @test iszero(output[2])
+
+    ## Do not add special tokens
+    output = encode(
+        encoder, long_text; split_instead_trunc = true, add_special_tokens = false)
+    @test size(output[1]) == (512, 2)
+    ## check that tokens were added correctly
+    @test output[1][1, :] == [7592, 2129]
+    @test output[1][end, :] == [1010, 0]
+    @test output[1][93, 2] == 0
+    @test size(output[3]) == (512, 2)
+    @test output[3][1, :] == [1, 1]
+    @test output[3][end, :] == [1, 0]
+    @test output[3][89, :] == [1, 1]
+    @test output[3][90, :] == [1, 0]
+    @test iszero(output[2])
 end


### PR DESCRIPTION
- Simplify embedding with the tiny models and provide native support for splitting of long strings into several smaller ones (kwarg `split_instead_trunc`)
